### PR TITLE
Removed Metrics For MultiGet

### DIFF
--- a/src/main/java/org/gooru/insights/services/BaseAPIService.java
+++ b/src/main/java/org/gooru/insights/services/BaseAPIService.java
@@ -56,4 +56,6 @@ public interface BaseAPIService {
 	Map<String, Boolean> checkPoint(RequestParamsDTO requestParamsDTO);
 	
 	<T> T deserialize(String json, Class<T> clazz);
+	
+	String convertSettoString(Set<String> inputDatas);
 }

--- a/src/main/java/org/gooru/insights/services/BaseAPIServiceImpl.java
+++ b/src/main/java/org/gooru/insights/services/BaseAPIServiceImpl.java
@@ -144,6 +144,18 @@ public class BaseAPIServiceImpl implements BaseAPIService {
 		return outDatas;
 	}
 
+	public String convertSettoString(Set<String> inputDatas) {
+
+		StringBuffer stringBuffer = new StringBuffer();
+		for(String inputData : inputDatas){
+			if(stringBuffer.length() > 0){
+				stringBuffer.append(APIConstants.COMMA);
+			}
+			stringBuffer.append(inputData);
+		}
+		return stringBuffer.toString();
+	}
+	
 	public Object[] convertSettoArray(Set<?> data) {
 		return data.toArray(new Object[data.size()]);
 	}

--- a/src/main/java/org/gooru/insights/services/BaseESServiceImpl.java
+++ b/src/main/java/org/gooru/insights/services/BaseESServiceImpl.java
@@ -350,6 +350,11 @@ public class BaseESServiceImpl implements BaseESService {
 			}
 			List<Map<String,Object>> queryResult = getBusinessLogicService().customizeJSON(traceId,requestParamsDTO.getGroupBy(), result, metricsName, validatedData,responseParamDTO,limit);
 			
+			/**
+			 * Added Fix to avoid metrics fields in multiget records
+			 */
+			removeMetricsFromFields(requestParamsDTO,metricsName);
+			
 			if(!validatedData.get(Hasdatas.HAS_GRANULARITY.check())){
 				queryResult = getBusinessLogicService().customPagination(requestParamsDTO.getPagination(), queryResult, validatedData);
 			}else{
@@ -360,6 +365,13 @@ public class BaseESServiceImpl implements BaseESService {
 		}else{
 			return getBusinessLogicService().getRecords(traceId,indices,responseParamDTO,result,dataKey);
 		}
+	}
+	
+	private void removeMetricsFromFields(RequestParamsDTO requestParamsDTO,Map<String,String> metricsName){
+
+		Set<String> fields = getBaseAPIService().convertStringtoSet(requestParamsDTO.getFields());
+		fields.removeAll(metricsName.keySet());
+		requestParamsDTO.setFields(getBaseAPIService().convertSettoString(fields));
 	}
 	
 	public Client getClient(String indexSource) {


### PR DESCRIPTION
Changes in coreGet,
Issue:
aggregated Metrics Field will be passed to MultiGet.
Passing of Metrics Field do nothing, But while Implementing the AD-557. it's affect in fetching the same name in MultiGet.
Fix:
Removed the aggregated Metrics Field from Fields parameter for MultiGet. 
This Issue only happens when we have aggregation "name" field and multiGet field has same name.
